### PR TITLE
Check if window is available to avoid error on server side

### DIFF
--- a/src/js/polyfills/CustomEvent.js
+++ b/src/js/polyfills/CustomEvent.js
@@ -1,6 +1,6 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
 (function() {
-    if (typeof window.CustomEvent === 'function') return false;
+    if (typeof window === 'undefined' || typeof window.CustomEvent === 'function') return false;
 
     function CustomEvent(event, params) {
         params = params || {


### PR DESCRIPTION
Window is undefined on server side, so we should check if it's available